### PR TITLE
feat: added highWaterMark for insert file into folder

### DIFF
--- a/drive/snippets/snippets.js
+++ b/drive/snippets/snippets.js
@@ -85,7 +85,7 @@ class DriveSnippets {
       };
       const media = {
         mimeType: 'image/jpeg',
-        body: fs.createReadStream('files/photo.jpg'),
+        body: fs.createReadStream('files/photo.jpg', {highWaterMark: 200}),
       };
       this.driveService.files.create({
         resource,


### PR DESCRIPTION
Added highWaterMark to /drive/snippets/snippets.js line: 88
to fix data loss when inserting .txt files which are 64-265KB to Google Drive folder.
Fixed this issue: https://github.com/google/google-api-nodejs-client/issues/1236