### PR TITLE
Export quickstarts. Fixes #65

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
     "extends": "google",
     "parserOptions": {
         "ecmaVersion": 8,
+        "sourceType": "module"
     },
     "env": {
         "node": true,

--- a/adminSDK/directory/index.js
+++ b/adminSDK/directory/index.js
@@ -20,7 +20,7 @@ const readline = require('readline');
 const {google} = require('googleapis');
 
 // If modifying these scopes, delete token.json.
-export const SCOPES = ['https://www.googleapis.com/auth/admin.directory.user'];
+const SCOPES = ['https://www.googleapis.com/auth/admin.directory.user'];
 // The file token.json stores the user's access and refresh tokens, and is
 // created automatically when the authorization flow completes for the first
 // time.
@@ -101,7 +101,7 @@ function storeToken(token) {
  *
  * @param {google.auth.OAuth2} auth An authorized OAuth2 client.
  */
-export function listUsers(auth) {
+function listUsers(auth) {
   const service = google.admin({version: 'directory_v1', auth});
   service.users.list({
     customer: 'my_customer',

--- a/adminSDK/directory/index.js
+++ b/adminSDK/directory/index.js
@@ -20,7 +20,7 @@ const readline = require('readline');
 const {google} = require('googleapis');
 
 // If modifying these scopes, delete token.json.
-const SCOPES = ['https://www.googleapis.com/auth/admin.directory.user'];
+export const SCOPES = ['https://www.googleapis.com/auth/admin.directory.user'];
 // The file token.json stores the user's access and refresh tokens, and is
 // created automatically when the authorization flow completes for the first
 // time.
@@ -101,7 +101,7 @@ function storeToken(token) {
  *
  * @param {google.auth.OAuth2} auth An authorized OAuth2 client.
  */
-function listUsers(auth) {
+export function listUsers(auth) {
   const service = google.admin({version: 'directory_v1', auth});
   service.users.list({
     customer: 'my_customer',
@@ -122,3 +122,8 @@ function listUsers(auth) {
   });
 }
 // [END admin_sdk_directory_quickstart]
+
+module.exports = {
+  SCOPES,
+  listUsers,
+};

--- a/adminSDK/reports/index.js
+++ b/adminSDK/reports/index.js
@@ -20,7 +20,7 @@ const readline = require('readline');
 const {google} = require('googleapis');
 
 // If modifying these scopes, delete token.json.
-export const SCOPES = ['https://www.googleapis.com/auth/admin.reports.audit.readonly'];
+const SCOPES = ['https://www.googleapis.com/auth/admin.reports.audit.readonly'];
 // The file token.json stores the user's access and refresh tokens, and is
 // created automatically when the authorization flow completes for the first
 // time.
@@ -101,7 +101,7 @@ function storeToken(token) {
  *
  * @param {google.auth.OAuth2} auth An authorized OAuth2 client.
  */
-export function listLoginEvents(auth) {
+function listLoginEvents(auth) {
   const service = google.admin({version: 'reports_v1', auth});
   service.activities.list({
     userKey: 'all',

--- a/adminSDK/reports/index.js
+++ b/adminSDK/reports/index.js
@@ -20,7 +20,7 @@ const readline = require('readline');
 const {google} = require('googleapis');
 
 // If modifying these scopes, delete token.json.
-const SCOPES = ['https://www.googleapis.com/auth/admin.reports.audit.readonly'];
+export const SCOPES = ['https://www.googleapis.com/auth/admin.reports.audit.readonly'];
 // The file token.json stores the user's access and refresh tokens, and is
 // created automatically when the authorization flow completes for the first
 // time.
@@ -101,7 +101,7 @@ function storeToken(token) {
  *
  * @param {google.auth.OAuth2} auth An authorized OAuth2 client.
  */
-function listLoginEvents(auth) {
+export function listLoginEvents(auth) {
   const service = google.admin({version: 'reports_v1', auth});
   service.activities.list({
     userKey: 'all',
@@ -122,3 +122,8 @@ function listLoginEvents(auth) {
    });
 }
 // [END admin_sdk_reports_quickstart]
+
+module.exports = {
+  SCOPES,
+  listLoginEvents,
+};

--- a/adminSDK/reseller/index.js
+++ b/adminSDK/reseller/index.js
@@ -20,7 +20,7 @@ const readline = require('readline');
 const {google} = require('googleapis');
 
 // If modifying these scopes, delete token.json.
-const SCOPES = ['https://www.googleapis.com/auth/apps.order'];
+export const SCOPES = ['https://www.googleapis.com/auth/apps.order'];
 // The file token.json stores the user's access and refresh tokens, and is
 // created automatically when the authorization flow completes for the first
 // time.
@@ -120,3 +120,8 @@ function listSubscriptions(auth) {
   });
 }
 // [END admin_sdk_reseller_quickstart]
+
+module.exports = {
+  SCOPES,
+  listSubscriptions,
+};

--- a/adminSDK/reseller/index.js
+++ b/adminSDK/reseller/index.js
@@ -20,7 +20,7 @@ const readline = require('readline');
 const {google} = require('googleapis');
 
 // If modifying these scopes, delete token.json.
-export const SCOPES = ['https://www.googleapis.com/auth/apps.order'];
+const SCOPES = ['https://www.googleapis.com/auth/apps.order'];
 // The file token.json stores the user's access and refresh tokens, and is
 // created automatically when the authorization flow completes for the first
 // time.

--- a/apps-script/quickstart/index.js
+++ b/apps-script/quickstart/index.js
@@ -117,3 +117,8 @@ function callAppsScript(auth) {
   });
 }
 // [END apps_script_api_quickstart]
+
+module.exports = {
+  SCOPES,
+  callAppsScript,
+};

--- a/calendar/quickstart/index.js
+++ b/calendar/quickstart/index.js
@@ -110,3 +110,8 @@ function listEvents(auth) {
   });
 }
 // [END calendar_quickstart]
+
+module.exports = {
+  SCOPES,
+  listEvents,
+};

--- a/classroom/quickstart/index.js
+++ b/classroom/quickstart/index.js
@@ -106,3 +106,8 @@ function listCourses(auth) {
   });
 }
 // [END classroom_quickstart]
+
+module.exports = {
+  SCOPES,
+  listCourses,
+};

--- a/docs/quickstart/index.js
+++ b/docs/quickstart/index.js
@@ -98,3 +98,8 @@ function printDocTitle(auth) {
   });
 }
 // [END docs_quickstart]
+
+module.exports = {
+  SCOPES,
+  printDocTitle,
+};

--- a/drive/activity-v2/index.js
+++ b/drive/activity-v2/index.js
@@ -218,3 +218,8 @@ function getTargetInfo(target) {
   return `${getOneOf(target)}:unknown`;
 }
 // [END drive_activity_v2_quickstart]
+
+module.exports = {
+  SCOPES,
+  listDriveActivity,
+};

--- a/drive/activity/index.js
+++ b/drive/activity/index.js
@@ -115,3 +115,8 @@ function listActivity(auth) {
   });
 }
 // [END drive_activity_quickstart]
+
+module.exports = {
+  SCOPES,
+  listActivity,
+};

--- a/drive/quickstart/index.js
+++ b/drive/quickstart/index.js
@@ -106,3 +106,8 @@ function listFiles(auth) {
   });
 }
 // [END drive_quickstart]
+
+module.exports = {
+  SCOPES,
+  listFiles,
+};

--- a/gmail/quickstart/index.js
+++ b/gmail/quickstart/index.js
@@ -106,3 +106,8 @@ function listLabels(auth) {
   });
 }
 // [END gmail_quickstart]
+
+module.exports = {
+  SCOPES,
+  listLabels,
+};

--- a/people/quickstart/index.js
+++ b/people/quickstart/index.js
@@ -112,3 +112,8 @@ function listConnectionNames(auth) {
   });
 }
 // [END people_quickstart]
+
+module.exports = {
+  SCOPES,
+  listConnectionNames,
+};

--- a/sheets/quickstart/index.js
+++ b/sheets/quickstart/index.js
@@ -108,3 +108,8 @@ function listMajors(auth) {
   });
 }
 // [END sheets_quickstart]
+
+module.exports = {
+  SCOPES,
+  listMajors,
+};

--- a/slides/quickstart/index.js
+++ b/slides/quickstart/index.js
@@ -102,3 +102,8 @@ function listSlides(auth) {
   });
 }
 // [END slides_quickstart]
+
+module.exports = {
+  SCOPES,
+  listSlides,
+};

--- a/tasks/quickstart/index.js
+++ b/tasks/quickstart/index.js
@@ -106,3 +106,8 @@ function listTaskLists(auth) {
   });
 }
 // [END tasks_quickstart]
+
+module.exports = {
+  SCOPES,
+  listTaskLists,
+};


### PR DESCRIPTION
## Export quickstarts. Fixes #65

- Adds `module.exports` after region tag to export `SCOPES` and function after region tag.
- Adds ESLint `"sourceType": "module"` to prevent IDE linting errors for modules.

Eventually these quickstarts could be tested with CI since the methods are now exported and usable in other files.