### PR TITLE
feat: Add main export for repo as module. Fixes #65.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,24 @@
+/**
+ * Exports all quickstarts.
+ */
+module.exports = {
+  quickstart: {
+    // Format {service}_{version}, like the Node client.
+    // @see https://github.com/googleapis/google-api-nodejs-client/tree/master/src/apis
+    admin_directory_v1: require('./adminSDK/directory'),
+    admin_reports_v1: require('./adminSDK/reports'),
+    reseller_v1: require('./adminSDK/reseller'),
+    script_v1: require('./apps-script/quickstart'),
+    calendar_v3: require('./calendar/quickstart'),
+    classroom_v1: require('./classroom/quickstart'),
+    docs_v1: require('./docs/quickstart'),
+    drive_v3: require('./drive/quickstart'),
+    appsactivity_v1: require('./drive/activity'),
+    appsactivity_v2: require('./drive/activity-v2'),
+    gmail_v1: require('./gmail/quickstart'),
+    people_v1: require('./people/quickstart'),
+    sheets_v4: require('./sheets/quickstart'),
+    slides_v1: require('./slides/quickstart'),
+    tasks_v1: require('./tasks/quickstart'),
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gsuite-node-samples",
+  "name": "@gsuite/samples",
   "version": "1.0.0",
   "description": "Node.js samples for [G Suite API](https://developers.google.com/gsuite/) docs.",
   "license": "MIT",
@@ -22,6 +22,7 @@
   "scripts": {
     "lint": "eslint **/*.js"
   },
+  "main": ".",
   "eslintIgnore": [
     "getFoldersUnderRoot.js",
     "**/node_modules/**"


### PR DESCRIPTION
# Adds main entry point to Node module

- Updates the name in preparation of publishing to npm. (Feel free to suggest a different name)
- (Does not modify `package.json#version` since this package has not been published yet.)
- Adds `index.js` that exports all quickstarts
  - We may want to export snippets too in the future.

## Example usage

```js
import {quickstart} from '@gsuite/samples'
const quickstart = quickstart.sheets_v4;

// TODO: Get `auth` object
console.log(quickstart.SCOPES);
quickstart.listMajors(auth);
```

I chose to put the quickstarts in a `quickstart` object so we can just do a for-loop through all quickstarts (since they have the same format).

## Future Considerations

In the future, we may consider:
- exporting a _consistent name_ for our quickstarts (i.e. `execute`/`run`).

    ```js
    module.exports = {
      SCOPES,
      execute,
    };
    ```

  (In TypeScript, this would be conforming to an `interface`:)
  ```ts
  {
    SCOPES: string[],
    execute: () => string
  }
  ```

- Testing quickstarts since they are now exported.
- Modifying the quickstart to return values instead of `console.log`ing values.
  - This will be a lot easier when we have `async/await` since we can add this return without modifying the quickstart that is embedded within developers.google.com